### PR TITLE
Add translations to the premises

### DIFF
--- a/src/Controller/Admin/DashboardController.php
+++ b/src/Controller/Admin/DashboardController.php
@@ -13,7 +13,13 @@ use Symfony\Component\Routing\Annotation\Route;
 
 class DashboardController extends AbstractDashboardController
 {
-    #[Route('/admin', name: 'admin')]
+    #[Route('/admin', name: 'admin_default_locale')]
+    public function indexDefaultLocale(): Response
+    {
+        return $this->render('@EasyAdmin/page/content.html.twig');
+    }
+
+    #[Route('/admin/{_locale}', name: 'admin')]
     public function index(): Response
     {
        return $this->render('@EasyAdmin/page/content.html.twig');
@@ -26,7 +32,8 @@ class DashboardController extends AbstractDashboardController
 
         return Dashboard::new()
             ->setTitle($name)
-            ->setFaviconPath($favicon);
+            ->setFaviconPath($favicon)
+            ->setLocales(['en', 'nl']);
     }
 
     public function configureMenuItems(): iterable

--- a/translations/messages.en.yml
+++ b/translations/messages.en.yml
@@ -1,0 +1,11 @@
+RealmSigningLog: Users
+Users: Users
+Dashboard: Dashboard
+Revoke batch: Revoke
+Serial: Id
+Requester: Requester
+Realm: Realm
+Client: Client
+Issued: Issued
+Revoked: Revoked
+Revoke: Revoke

--- a/translations/messages.nl.yml
+++ b/translations/messages.nl.yml
@@ -1,0 +1,12 @@
+RealmSigningLog: Gebruikers
+Users: Gebruikers
+Dashboard: Dashboard
+Revoke batch: Intrekken
+Serial: Volgnummer
+Requester: Aanvrager
+Realm: Realm
+Client: Klant
+Issued: Uitgegeven
+Revoked: Ingetrokken
+Revoke: Intrekken
+


### PR DESCRIPTION
Both English and Dutch are supported. An user can easily switch between languages from the settings menu.